### PR TITLE
Fix Python 3 issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "2.7"
 env:
-  - TOXENV=py26
   - TOXENV=py27
   - TOXENV=py33
   - TOXENV=py34

--- a/README.rst
+++ b/README.rst
@@ -68,10 +68,21 @@ Via GitHub::
     $ python djangoappsettings/setup.py install
 
 
+Testing
+=======
+
+Install tox and run the tests::
+
+    $ git clone git://github.com/adammck/djappsettings.git
+    $ pip install tox
+    $ cd djappsettings
+    $ tox
+
+
 Bugs?
 =====
 
-This was created to scratch an itch for the `RapidSMS`_ project. I hope it will be useful to you, but it doesn't have any docs or tests yet, and hasn't been field tested. There are almost certainly bugs. Use it at your own risk. (But do use it, because it's *way* better.)
+This was created to scratch an itch for the `RapidSMS`_ project. I hope it will be useful to you. Use it at your own risk. (But do use it, because it's *way* better.)
 
 Patches and pull requests are very welcome.
 Please file bugs on `GitHub`_.

--- a/app_with_import_error/settings.py
+++ b/app_with_import_error/settings.py
@@ -1,0 +1,3 @@
+import blah  # noqa
+
+# ^ Generate an ImportError to make sure we don't mask it

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="djappsettings",
-    version="0.2.1",
+    version="0.3.0",
     license="BSD",
 
     author="Adam Mckaig",
@@ -15,6 +15,19 @@ setup(
 
     description="Per-app default settings for Django",
     url="http://github.com/adammck/djappsettings",
-    packages=find_packages(),
+    packages=find_packages(exclude=['app_with_import_error']),
     test_suite='tests',
+    classifiers=[
+        'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Framework :: Django',
+        'Development Status :: 5 - Production/Stable',
+        'Operating System :: OS Independent',
+    ],
 )

--- a/tests/default.py
+++ b/tests/default.py
@@ -1,0 +1,1 @@
+SECRET_KEY = 'not-secret'

--- a/tests/test_djappsettings.py
+++ b/tests/test_djappsettings.py
@@ -1,8 +1,77 @@
+from mock import patch
 import unittest
+
+import django
+from django.conf import settings as project_settings
+
 from djappsettings import settings
 
 
 class DjAppSettingsTest(unittest.TestCase):
 
-    def test_import(self):
-        self.assertTrue(settings)
+    def setUp(self):
+        if django.VERSION > (1, 7):
+            django.setup()
+        settings._modules = None
+        settings._strict = True
+        project_settings.INSTALLED_APPS = ['djappsettings']
+
+    def test_finds_project_setting(self):
+        self.assertEqual(settings.SECRET_KEY, 'not-secret')
+
+    def test_skips_apps_without_settings(self):
+        project_settings.INSTALLED_APPS = ['django.contrib.admin']
+        self.assertEqual(settings.SECRET_KEY, 'not-secret')
+
+    # patch settings._import to return a module with settings that we specify
+
+    @patch.object(settings, '_import')
+    def test_masks_global_settings_raises_error(self, mock_module):
+        # Should raise AttributeError if we mask a global setting like ADMINS
+        mock_module.return_value.ADMINS = 'blah'
+        with self.assertRaises(AttributeError):
+            settings.ADMINS
+
+    @patch.object(settings, '_import')
+    def test_masks_global_settings_not_strict(self, mock_module):
+        # if DJAPPSETTINGS_STRICT is False, then don't raise error
+        mock_module.return_value.ADMINS = 'blah'
+        settings._strict = False
+        self.assertEqual(settings.ADMINS, ())
+
+    @patch.object(settings, '_import')
+    def test_finds_module_setting(self, mock_module):
+        mock_module.return_value.MODULE_SPECIFIC_SETTING = 'blah'
+        self.assertEqual(settings.MODULE_SPECIFIC_SETTING, 'blah')
+
+    @patch.object(settings, '_import')
+    def test_duplicate_module_setting_raises_error(self, mock_module):
+        mock_module.return_value.MODULE_SPECIFIC_SETTING = 'blah'
+        # putting 2 apps in INSTALLED_APPS will make Mock try to give each of them
+        # the same setting (MODULE_SPECIFIC_SETTING)
+        project_settings.INSTALLED_APPS = ['django.contrib.admin', 'djappsettings']
+        with self.assertRaises(AttributeError):
+            settings.MODULE_SPECIFIC_SETTING
+        # But hasattr should never fail
+        settings._modules = None
+        self.assertFalse(hasattr(settings, 'MODULE_SPECIFIC_SETTING'))
+
+    @patch.object(settings, '_import')
+    def test_duplicate_module_setting_not_strict(self, mock_module):
+        mock_module.return_value.MODULE_SPECIFIC_SETTING = 'blah'
+        # putting 2 apps in INSTALLED_APPS will make Mock try to give each of them
+        # the same setting (MODULE_SPECIFIC_SETTING)
+        project_settings.INSTALLED_APPS = ['django.contrib.admin', 'djappsettings']
+        settings._strict = False
+        # if DJAPPSETTINGS_STRICT is False, then don't raise error
+        self.assertEqual(settings.MODULE_SPECIFIC_SETTING, 'blah')
+
+    def test_hasattr_should_not_fail(self):
+        # hasattr should return False if setting is not defined
+        # Currently, it blows up with ValueError on Python 3
+        self.assertFalse(hasattr(settings, 'FAKE_SETTING'))
+
+    def test_error_in_settings_isnt_masked(self):
+        project_settings.INSTALLED_APPS = ['app_with_import_error', ]
+        with self.assertRaises(ImportError):
+            settings.SECRET_KEY

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
-envlist = py26, py27, py33, py34, flake8, coverage
+envlist = py27, py33, py34, flake8, coverage
 
 [testenv]
 commands = {envpython} setup.py test
-deps = django>1.4
+deps = django
+       mock
+setenv = DJANGO_SETTINGS_MODULE = tests.default
 
 [flake8]
 exclude = .tox
@@ -11,12 +13,13 @@ ignore = E128
 max-line-length = 120
 
 [testenv:flake8]
-deps = flake8>2.2.2
+deps = flake8
 commands = flake8 .
 
 [testenv:coverage]
 basepython = python2.7
 commands = coverage run setup.py test
            coverage report -m --fail-under=80
-deps = coverage>=3.7.1
-       django>1.4
+deps = coverage
+       django
+       mock


### PR DESCRIPTION
Python 3 causes 2 problems with the current code:

1. `hasattr` now only catches `AttributeError`, so throwing `ValueError` causes `hasattr` to fail, which we don't want.
2. Python 3 tracebacks look different than Python 2 ones, so the code to identify where `ImportError` was thrown doesn't work.

This fixes those 2 issues, with tests (100% coverage!)